### PR TITLE
Fix vehicles gaining fuel when reversing

### DIFF
--- a/src/main/java/com/flansmod/common/driveables/EntityVehicle.java
+++ b/src/main/java/com/flansmod/common/driveables/EntityVehicle.java
@@ -390,7 +390,7 @@ public class EntityVehicle extends EntityDriveable implements IExplodeable
 			{
 				if (!driverIsCreative())
 				{
-					data.fuelInTank -= data.engine.fuelConsumption * throttle;
+					data.fuelInTank -= data.engine.fuelConsumption * Math.abs(throttle);
 				}
 
 				if(getVehicleType().tank)


### PR DESCRIPTION
Because the fuel consumption was calculated by multiplicating with the current throttle, the consumption got negative when reversing.