### PR TITLE
Fix silenced guns not shooting silently

### DIFF
--- a/src/main/java/com/flansmod/common/guns/ItemGun.java
+++ b/src/main/java/com/flansmod/common/guns/ItemGun.java
@@ -637,7 +637,7 @@ public class ItemGun extends Item implements IPaintableItem
 		// Play shot sounds
 		if(soundDelay <= 0 && type.shootSound != null)
 		{
-			PacketPlaySound.sendSoundPacket(position.x, position.y, position.z, FlansMod.soundRange, world.provider.getDimension(), type.shootSound, silenced);
+			PacketPlaySound.sendSoundPacket(position.x, position.y, position.z, FlansMod.soundRange, world.provider.getDimension(), type.shootSound, type.distortSound, silenced);
 			soundDelay = type.idleSoundLength;
 		}
 	}

--- a/src/main/java/com/flansmod/common/network/PacketPlaySound.java
+++ b/src/main/java/com/flansmod/common/network/PacketPlaySound.java
@@ -103,7 +103,7 @@ public class PacketPlaySound extends PacketBase
 		FMLClientHandler.instance().getClient().getSoundHandler().playSound(
 				new PositionedSoundRecord(event,
 						SoundCategory.PLAYERS,
-						silenced ? 2F : 4F,
+						silenced ? 0.5F : 4F,
 						(distort ? 1.0F / (rand.nextFloat() * 0.4F + 0.8F) : 1.0F) * (silenced ? 2F : 1F),
 						posX, posY, posZ));
 		


### PR DESCRIPTION
Fixes #7 

Silencers on guns didn't work because of the boolean "silenced" being used as wrong parameter in method.
Now they do.